### PR TITLE
Port RETURNDATALOAD from EIP-7069 PR

### DIFF
--- a/spec/eof.md
+++ b/spec/eof.md
@@ -274,6 +274,11 @@ Code executing within an EOF environment will behave differently than legacy cod
     - `n = imm >> 4 + 1`, `m = imm & 0x0F + 1`
     - `n`th stack item is swapped with `n + m`th stack item (1-based).
     - Stack validation: `stack_height >= n + m`
+- `RETURNDATALOAD (0xf7)` instruction
+    - deduct 3 gas
+    - pop `offset` from the stack
+    - if `offset + 32 > len(returndata buffer)`, execution results in an exceptional halt
+    - push 1 item onto the stack, the 32-byte word read from the returndata buffer starting at `offset`
 
 ## Code Validation
 


### PR DESCRIPTION
One of last pending discussion items. The changes are ported directly from https://github.com/ethereum/EIPs/pull/7820/files, only with an update to the language to match the mega spec.

As I understand, this proposition should accompany the revamping of `*CALL` instructions, otherwise there might be code regressions (from Vyper team).

There has been discussion on changing the RETURNDATA* semantics to pad with zero instead of halting on OOB, but this PR follows the EIP PR in keeping the (halt exceptionally) behavior. Unless there is a compelling reason to change to zero pad, I would keep it like that to not bloat the EOF change.