### PR TITLE
Move DATA* opcodes to the D section

### DIFF
--- a/spec/eof.md
+++ b/spec/eof.md
@@ -238,18 +238,18 @@ Code executing within an EOF environment will behave differently than legacy cod
     - ends initcode frame execution and returns control to CREATE3/4 caller frame where `deploy_container_index` and `aux_data` are used to construct deployed contract (see above)
     - instruction exceptionally aborts if after the appending, data section size would overflow the maximum data section size or underflow (i.e. be less than data section size declared in the header)
     - instruction exceptionally aborts if invoked not in "initcode-mode"
-- `DATALOAD (0xe8)` instruction
+- `DATALOAD (0xd0)` instruction
     - deduct 4 gas
     - pop one value, `offset`, from the stack
     - read `[offset, offset+32]` from the data section of the active container and push the value to the stack
     - pad with 0s if reading out of data bounds
-- `DATALOADN (0xe9)` instruction
+- `DATALOADN (0xd1)` instruction
     - deduct 3 gas
     - like `DATALOAD`, but takes the offset as a 16-bit immediate value and not from the stack
-- `DATASIZE (0xea)` instruction
+- `DATASIZE (0xd2)` instruction
     - deduct 2 gas
     - push the size of the data section of the active container to the stack
-- `DATACOPY (0xeb)` instruction
+- `DATACOPY (0xd3)` instruction
     - deduct 3 gas
     - pops `mem_offset`, `offset`, `size` from the stack
     - perform memory expansion to `mem_offset + size` and deduct memory expansion cost


### PR DESCRIPTION
Closes #43 

There is a [conflict of EXCHANGE and DATALOAD](https://github.com/ethereum/EIPs/pull/7819#discussion_r1446254404) and the E section is full.

It has been noted the E section could be for Emmediates, but we'd need to separate a bunch of opcodes otherwise related, and would likely run out of opcode slots in E section anyway quite soon.

My quick pitch for the move to D is to instead leave opcodes logically bound to EOF in `E` leaving plenty of space there for the future. As such, `D`ata ~and stack~ lands in D.

Let's quickly gather feedback on this. If there's objections, I'll do an alternative PR to do the Emmediates change and we go with that instead.