### PR TITLE
Allow RETURN/STOP in EOF creation tx code

### DIFF
--- a/spec/eof.md
+++ b/spec/eof.md
@@ -136,18 +136,18 @@ Creation transactions (tranactions with empty `to`), with `data` containing EOF 
     - Find `intcontainer` size by reading all section sizes from the header and adding them up with the header size to get the full container size.
 3. Validate the `initcontainer` and all its subcontainers recursively.
     - unlike in general validation `initcontainer` is additionally required to have `data_size` declared in the header equal to actual `data_section` size.
-    - validation includes checking that the container is an "initcode" container as defined in the validation section, that is, it does not contain `RETURN` or `STOP`
 4. If EOF header parsing or full container validation fails, transaction is considered valid and failing. Gas for initcode execution is not consumed, only intrinsic creation transaction costs are charged.
 5. `calldata` part of transaction `data` that follows `initcontainer` is treated as calldata to pass into the execution frame
 6. execute the container and deduct gas for execution
     1. Calculate `new_address` as `keccak256(sender || sender_nonce)[12:]`
-    2. A successful execution ends with initcode executing `RETURNCONTRACT{deploy_container_index}(aux_data_offset, aux_data_size)` instruction (see below). After that:
+    2. Execution may end with initcode executing `RETURNCONTRACT{deploy_container_index}(aux_data_offset, aux_data_size)` instruction (see below). After that:
         - load deploy-contract from EOF subcontainer at `deploy_container_index` in the container from which `RETURNCONTRACT` is executed
         - concatenate data section with `(aux_data_offset, aux_data_offset + aux_data_size)` memory segment and update data size in the header
         - let `deployed_code_size` be updated deploy container size
         - if `deployed_code_size > MAX_CODE_SIZE` instruction exceptionally aborts
         - set `state[new_address].code` to the updated deploy container
-7. deduct `200 * deployed_code_size` gas
+        - deduct `200 * deployed_code_size` gas
+    3. If execution ends with `RETURN` or `STOP`, no code is deployed
 
 **NOTE** Legacy contract and legacy creation transactions may not deploy EOF code, that is behavior from [EIP-3541](https://eips.ethereum.org/EIPS/eip-3541) is not modified.
 


### PR DESCRIPTION
Sibling PR of https://github.com/ipsilon/eof/pull/118. This time we drop the requirement for `initcontainer` s in EOF creation txs be actually validated to be... "initcontainers", in the sense of not containing RETURN/STOP.

The effect of this is that they can actually RETURN or STOP (without deploying any contract!), **in addition to RETURNCONTRACT**. So now the creation tx has access to the salt-based hashing scheme, and we also don't care about runtime/initcode mode of such containers.

Opening the PR just to assess the fresh idea in writing, **does not mean yet** we're changing the spec.

