### PR TITLE
Require MAX_INITCODE_SIZE limit to be satisfied during validation

### DIFF
--- a/spec/eof.md
+++ b/spec/eof.md
@@ -106,6 +106,8 @@ The following validity constraints are placed on the container format:
 - the total size of a deployed container without container sections must be `13 + 2*num_code_sections + types_size + code_size[0] + ... + code_size[num_code_sections-1] + data_size`
 - the total size of a deployed container with at least one container section must be `16 + 2*num_code_sections + types_size + code_size[0] + ... + code_size[num_code_sections-1] + data_size + 2*num_container_sections + container_size[0] + ... + container_size[num_container_sections-1]`
 - the total size of not yet deployed container might be up to `data_size` lower than the above values due to how the data section is rewritten and resized during deployment (see [Data Section Lifecycle](#data-section-lifecycle))
+- the total size of a container must not exceed `MAX_INITCODE_SIZE` (as defined in EIP-3860)
+    - **NOTE** this condition, in combination with the container format defined above, implies that validation should fail at the moment any section is found to be declared to end after the last byte of the container
 
 ## Execution Semantics
 


### PR DESCRIPTION
Pushing in form of a PR after discussion during [EOF implementers call 49](https://github.com/ethereum/pm/issues/1055).

To reiterate the reasoning behind:

### Synopsis of the problem: 

  - subcontainer have size limit of 64K implied by the header format
  - but this doesn't apply to "top-level" containers!
  - we have EIP-3860 MAX_INITCODE_SIZE of 48K - but not part of EOF validation!
  - EVM implementations doing `validate_eof` and handling the containers/headers must make assumptions about the maximum size of the container to expect and handle
    - is it MAX_INITCODE_SIZE?
    - is it 64K, same as subcontainer?
    - is it whatever can be maxed out with sections, i.e. max code sections, then max of max container sections and max data size?
    - is it some yet other value?
  - for example, evmone had a [subtle bug](https://github.com/ethereum/evmone/pull/891), where large top-level containers had "overflown" data_section_offset persisted in the header, because offsets were expected to not exceed 64K

### Proposal

Introduce a validation rule of max top-level container size of MAX_INITCODE_SIZE 48K (or twice that constant, for practical reasons like solidity testing methods). Whenever either the bytestring being the top-level container **or** the declared (in the header, as discovered during header parsing) size of the top-level container exceed that, validation fails.


