### PR TITLE
Clarify RJUMP successors and EXTCODE* for mid-creation targets

### DIFF
--- a/spec/eof.md
+++ b/spec/eof.md
@@ -335,7 +335,7 @@ During scanning, for each instruction:
       - terminating instructions do not need to update stack heights.
 3. Determine the list of successor instructions that can follow the current instructions:
    1. The next instruction for all instructions other than terminating instructions and `RJUMP`.
-   2. All targets of a `RJUMPI` or `RJUMPV`.
+   2. All targets of an `RJUMP`, `RJUMPI` or `RJUMPV`.
 4. For each successor instruction:
    1. Check if the instruction is present in the code (i.e. execution must not "fall off" the code).
       - This implies that the last instruction may be a terminating instruction or `RJUMP`

--- a/spec/eof.md
+++ b/spec/eof.md
@@ -128,6 +128,8 @@ Code executing within an EOF environment will behave differently than legacy cod
 - `RETURNDATACOPY (0x3E)` instruction
     - same behavior as legacy, but changes the exceptional halt behavior to zero-padding behavior (same behavior as `CALLDATACOPY`).
 
+**NOTE** Like for legacy targets, the aforementioned behavior of `EXTCODECOPY`, `EXTCODEHASH` and `EXTCODESIZE` does not apply to EOF contract targets mid-creation, i.e. those report same as accounts without code.
+
 #### Creation transactions
 
 Creation transactions (tranactions with empty `to`), with `data` containing EOF code (starting with `EF00` magic) are interpreted as having a concatenation of EOF `initcontainer` and `calldata` in the `data` and:


### PR DESCRIPTION
not sure about the wording for the mid-creation stuff. Don't want to over-formalize it, as it is a clarification, not spec.