### PR TITLE
update num container sections

### DIFF
--- a/spec/eof.md
+++ b/spec/eof.md
@@ -39,7 +39,7 @@ _note: `,` is a concatenation operator, `+` should be interpreted as "one or mor
 | num_code_sections | 2 bytes  | 0x0001-0xFFFF | 16-bit unsigned big-endian integer denoting the number of the code sections |
 | code_size         | 2 bytes  | 0x0001-0xFFFF | 16-bit unsigned big-endian integer denoting the length of the code section content |
 | kind_container    | 1 byte   | 0x03          | kind marker for container size section |
-| num_container_sections | 2 bytes  | 0x0001-0x00FF | 16-bit unsigned big-endian integer denoting the number of the container sections |
+| num_container_sections | 2 bytes  | 0x0001-0x0100 | 16-bit unsigned big-endian integer denoting the number of the container sections |
 | container_size    | 2 bytes  | 0x0001-0xFFFF | 16-bit unsigned big-endian integer denoting the length of the container section content |
 | kind_data         | 1 byte   | 0x04          | kind marker for data size section |
 | data_size         | 2 bytes  | 0x0000-0xFFFF | 16-bit unsigned big-endian integer denoting the length of the data section content (for not yet deployed containers this can be more than the actual content, see [Data Section Lifecycle](#data-section-lifecycle))|


### PR DESCRIPTION
Reflects that in order to encode 255 num container sections, one does not use 0x00FF, but 0x0100, due to the rule that the num container sections encoded should be at lest 0x0000, in order to avoid 0x030000 