### PR TITLE
Change new address calculation for EOFCREATE to include hashed input

### DIFF
--- a/spec/eof.md
+++ b/spec/eof.md
@@ -202,13 +202,13 @@ The following instructions are introduced in EOF code:
     - peform (and charge for) memory expansion using `[input_offset, input_size]`
     - load initcode EOF subcontainer at `initcontainer_index` in the container from which `EOFCREATE` is executed
         - let `initcontainer` be that EOF container, and `initcontainer_size` its length in bytes
-    - deduct `6 * ((initcontainer_size + 31) // 32)` gas (hashing charge)
+    - deduct `6 * ((initcontainer_size + 31) // 32 + (input_size + 31) // 32)` gas (hashing charge)
     - check call depth limit and whether caller balance is enough to transfer `value`
         - in case of failure returns 0 on the stack, caller's nonce is not updated and gas for initcode execution is not consumed.
-    - caller's memory slice [`input_offset`:`input_size`] is used as calldata
+    - caller's memory slice [`input_offset`:`input_size`] is used as calldata (`input`)
     - execute the container and deduct gas for execution. The 63/64th rule from EIP-150 applies.
         - increment `sender` account's nonce
-        - calculate `new_address` as `keccak256(0xff || sender || salt || keccak256(initcontainer))[12:]`
+        - calculate `new_address` as `keccak256(0xff || sender || salt || keccak256(initcontainer) || keccak256(input))[12:]`
         - an unsuccesful execution of initcode results in pushing `0` onto the stack
             - can populate returndata if execution `REVERT`ed
         - a successful execution ends with initcode executing `RETURNCONTRACT{deploy_container_index}(aux_data_offset, aux_data_size)` instruction (see below). After that:


### PR DESCRIPTION
Current address calculation scheme goes against Solidity users' expectations, because in legacy constructor arguments are concatenated with `initcode`, and so they are included in hashing too.  And in EOF `initcode` is only container without runtime arguments.

In particular, this case is broken, contract `B` creations would collide in EOF but not in legacy:
```solidity
contract B
{
    uint x;
    function getBalance() public view returns (uint) {
        return address(this).balance * 1000 + x;
    }
    constructor(uint _x) payable {
        x = _x;
    }
}

contract A {
    function f() public payable returns (uint, uint, uint) {
        B x = new B{salt: "abc", value: 3}(7);
        B y = new B{value: 3, salt: "abc"}(8);
        B z = new B{salt: "abc", value: 3}(9);
        return (x.getBalance(), y.getBalance(), z.getBalance());
    }
}
```

In EOF we could include `input` of `EOFCREATE` in address derivation to make it `keccak256(0xff || sender || salt || keccak256(initcontainer) || keccak256(input))[12:]`.

Potential arguments against could be:
- users would need to pay for `input` hashing even in case the don't deploy this contract more than once.
- users can use `salt` to prevent collision if they deploy multiple times, so it's not essential, and the spec for address and gas calculations is simpler without this.
- generally `input` is not what goes into deployed code, but some ephemeral constructor arguments, not directly related.
