### PR TITLE
Remove ban of EXTCODESIZE

### DIFF
--- a/spec/eof.md
+++ b/spec/eof.md
@@ -111,10 +111,10 @@ Code executing within an EOF environment will behave differently than legacy cod
 
 - Execution starts at the first byte of code section 0, and `pc` is set to 0.
 - `pc` is scoped to the executing code section
-- The instructions `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`, `SELFDESTRUCT`, `JUMP`, `JUMPI`, `PC`, `CREATE`, `CREATE2`, `CODESIZE`, `CODECOPY`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`, `GAS` are deprecated and rejected by validation in EOF contracts. They are only available in legacy contracts.
+- The instructions `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`, `SELFDESTRUCT`, `JUMP`, `JUMPI`, `PC`, `CREATE`, `CREATE2`, `CODESIZE`, `CODECOPY`, `EXTCODECOPY`, `EXTCODEHASH`, `GAS` are deprecated and rejected by validation in EOF contracts. They are only available in legacy contracts.
 - When executed from a legacy contract, if the target account of `EXTCODECOPY` is an EOF contract, then it will copy up to 2 bytes from `EF00`, as if that would be the code.
 - When executed from a legacy contract, if the target account of `EXTCODEHASH` is an EOF contract, then it will return `0x9dbf3648db8210552e9c4f75c6a1c3057c0ca432043bd648be15fe7be05646f5` (the hash of `EF00`, as if that would be the code).
-- When executed from a legacy contract, if the target account of `EXTCODESIZE` is an EOF contract, then it will return 2.
+- if the target account of `EXTCODESIZE` is an EOF contract, then it will return 2.
 - The instruction `JUMPDEST` is renamed to `NOP` and remains charging 1 gas without any effect.
     - Note: jumpdest-analysis is not performed anymore.
 - EOF contract may not deploy legacy code (it is naturally rejected on the code validation stage)


### PR DESCRIPTION
Starting the move tentatively decided on during [EOF implementers call](https://github.com/ethereum/pm/issues/1102).

Will proceed to EIPs/EEST/evmone next.

EXTCODEHASH unbanning was also discussed, but the decision was to start small and possibly expand in the next step.