### PR TITLE
Align EOFCREATE stack args with EXTCALL

### DIFF
--- a/spec/eof.md
+++ b/spec/eof.md
@@ -227,7 +227,7 @@ The following instructions are introduced in EOF code:
     - deduct `32000` gas
     - halt with exceptional failure if the current frame is in `static-mode`.
     - read uint8 operand `initcontainer_index`
-    - pops `value`, `salt`, `input_offset`, `input_size` from the stack
+    - pops `salt`, `input_offset`, `input_size`, `value` from the stack
     - perform (and charge for) memory expansion using `[input_offset, input_size]`
     - load initcode EOF subcontainer at `initcontainer_index` in the container from which `EOFCREATE` is executed
         - let `initcontainer` be that EOF container, and `initcontainer_size` its length in bytes


### PR DESCRIPTION
It has been brought to attention in https://ethereum-magicians.org/t/eip-7620-eof-contract-creation-instructions/18625/4 that the stack args of EOFCREATE do not align with CREATE2. This is something good, since args of those opcodes have unintuitively distinct meaning - namely the input buffer.

However we seem to be missing out on an opportunity to align the EOFCREATE stack args with another closely related opcode: EXTCALL. They differ only by a single argument (`salt` vs `target_address`) per [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069), so we could aim to make them aligned.