### PR TITLE
chore: Update Revm testing matrix

### DIFF
--- a/spec/implementation_matrix.md
+++ b/spec/implementation_matrix.md
@@ -44,12 +44,12 @@
 |------------------------------------------------------|--------|----------|--------------|----------|--------|--------------|--------|--------|
 | [EEST] `eip7692@v1.0.7` - `state_tests`              | ✅     |          | ✅           | ✅       |        |              | ✅     |        |
 | [EEST] `eip7692@v1.0.7` - `eof_tests`                | ✅     | ❓       | ✅           | ✅       |        |              | ✅     |        |
-| [EEST] `eip7692@v1.0.8` - `state_tests`              | ✅     |          |              | ✅       |        | ✅           |        |        |
-| [EEST] `eip7692@v1.0.8` - `eof_tests`                | ✅     |          |              | ✅       |        |              |        |        |
+| [EEST] `eip7692@v1.0.8` - `state_tests`              | ✅     |          |              | ✅       |        | ✅           | ✅       |        |
+| [EEST] `eip7692@v1.0.8` - `eof_tests`                | ✅     |          |              | ✅       |        |              | ✅    |        |
 | \[\*\] [tests] `v14.0` - `EIPTests/StateTests/stEOF` | ✅     |          |              | ✅       |        |              | ✅     |        |
 | \[\*\] [tests] `v14.0` - `EOFTests`                  | ✅     |          |              | ✅       |        |              | ✅     |        |
-| [tests] `v14.1` - `EIPTests/StateTests/stEOF`        |       |          |              | ✅       |        |              |       |        |
-| [tests] `v14.1` - `EOFTests`                         |       |          |              | ✅       |        |              |       |        |
+| [tests] `v14.1` - `EIPTests/StateTests/stEOF`        |       |          |              | ✅       |        |              | ✅    |        |
+| [tests] `v14.1` - `EOFTests`                         |       |          |              | ✅       |        |              | ✅    |        |
 | \[\*\*\] (`evmone` (old) `70ca837` - `state_tests`)  | ✅     |          | ✅           | ✅       |        |              |        |        |
 | \[\*\*\] (`evmone` (old) `70ca837` - `eof_tests`)    | ✅     |          | ✅           | ✅       |        |              |        |        |
 | [`evmone` exported] `v0.12.0` - `state_tests`        | ✅     |          |              | ✅       |        |              | ✅     |        |


### PR DESCRIPTION
`EEST`, have run a slightly newer test suite from this PR: https://github.com/ethereum/execution-spec-tests/pull/768

`ethereum/tests` are run on every Revm PR:
statetests: https://github.com/bluealloy/revm/blob/89b65e1e4b5bbb2ddba4f414ca41ce3f8ad9758d/.github/workflows/ethereum-tests.yml#L51
EOF validation: https://github.com/bluealloy/revm/blob/89b65e1e4b5bbb2ddba4f414ca41ce3f8ad9758d/.github/workflows/ethereum-tests.yml#L58