### PR TITLE
Change definition of `m` in EXCHANGE

### DIFF
--- a/spec/eof.md
+++ b/spec/eof.md
@@ -256,9 +256,9 @@ The following instructions are introduced in EOF code:
 - `EXCHANGE (0xe8)` instruction
     - deduct 3 gas
     - read uint8 operand `imm`
-    - `n = imm >> 4 + 1`, `m = imm & 0x0F + 1`
-    - `n + 1`th stack item is swapped with `n + m + 1`th stack item (1-based).
-    - Stack validation: `stack_height >= n + m + 1`
+    - `n = imm >> 4 + 1`, `m = imm & 0x0F + n + 1`
+    - `n + 1`th stack item is swapped with `m + 1`th stack item (1-based).
+    - Stack validation: `stack_height >= m + 1`
 - `RETURNDATALOAD (0xf7)` instruction
     - deduct 3 gas
     - pop `offset` from the stack

--- a/spec/eof.md
+++ b/spec/eof.md
@@ -256,7 +256,8 @@ The following instructions are introduced in EOF code:
 - `EXCHANGE (0xe8)` instruction
     - deduct 3 gas
     - read uint8 operand `imm`
-    - `n = imm >> 4 + 1`, `m = imm & 0x0F + n + 1`
+    - `i = imm >> 4`, `j = imm & 0x0F`
+    - `n = i + 1`, `m = j + i + 2`
     - `n + 1`th stack item is swapped with `m + 1`th stack item (1-based).
     - Stack validation: `stack_height >= m + 1`
 - `RETURNDATALOAD (0xf7)` instruction


### PR DESCRIPTION
The encoding of the operands in the bytecode remains the same, but conceptually `m` is defined as an absolute stack depth rather than relative to `n`.

This is meant to be reflected in the textual representation of the instruction in assembly, which should be `EXCHANGE n m`. The notation should be more intuitive with this change. In particular:

1. The order of immediates is irrelevant as one would expect. `EXCHANGE n m` and `EXCHANGE m n` are equivalent.
2. `EXCHANGE n m` can be understood as exactly equivalent to `SWAPN n SWAPN m SWAPN n` (minus different valid ranges for n,m).

